### PR TITLE
Use URL API to construct Google Places request URL

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -52,7 +52,10 @@ export const handler = async (event) => {
 
     const apiKey = await getGoogleApiKey();
     const fields = "name,rating,user_ratings_total,url,reviews";
-    const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${encodeURIComponent(GOOGLE_PLACE_ID)}&fields=${fields}&key=${encodeURIComponent(apiKey)}`;
+    const url = new URL("https://maps.googleapis.com/maps/api/place/details/json");
+    url.searchParams.set("place_id", GOOGLE_PLACE_ID);
+    url.searchParams.set("fields", fields);
+    url.searchParams.set("key", apiKey);
 
     const r = await fetch(url, { method: "GET" });
     const json = await r.json();


### PR DESCRIPTION
## Summary
- build the Google Places details endpoint URL using the URL and URLSearchParams APIs to avoid multiline template strings

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf16b5dce88324b0815aa42a09f856